### PR TITLE
Solves creating binreadcounts

### DIFF
--- a/R/ACE.R
+++ b/R/ACE.R
@@ -130,7 +130,7 @@ runACE <- function(inputdir = "./", outputdir, filetype = 'rds', genome = "hg19"
 	  for (b in binsizes) {
 		  currentdir <- file.path(outputdir,paste0(b,"kbp"))
 		  dir.create(currentdir)
-		  bins <- QDNAseq::getBinAnnotations(binSize = b, genome = genome)
+		  bins <- QDNAseq::getBinAnnotations(binSize = b, genome = genome, chunkSize = 10e6)
 		  readCounts <- QDNAseq::binReadCounts(bins, path = inputdir)
 		  if (savereadcounts == TRUE) {
 		    saveRDS(readCounts, file = file.path(outputdir, paste0(b, "kbp-raw.rds")))

--- a/R/ACE.R
+++ b/R/ACE.R
@@ -130,8 +130,8 @@ runACE <- function(inputdir = "./", outputdir, filetype = 'rds', genome = "hg19"
 	  for (b in binsizes) {
 		  currentdir <- file.path(outputdir,paste0(b,"kbp"))
 		  dir.create(currentdir)
-		  bins <- QDNAseq::getBinAnnotations(binSize = b, genome = genome, chunkSize = 10e6)
-		  readCounts <- QDNAseq::binReadCounts(bins, path = inputdir)
+		  bins <- QDNAseq::getBinAnnotations(binSize = b, genome = genome)
+		  readCounts <- QDNAseq::binReadCounts(bins, path = inputdir,  chunkSize = 10e6)
 		  if (savereadcounts == TRUE) {
 		    saveRDS(readCounts, file = file.path(outputdir, paste0(b, "kbp-raw.rds")))
 		  }


### PR DESCRIPTION
Reading really large BAM files with QDNAseq can cause memory allocation error as described in issue #4 resolved using chunksizes as described in https://github.com/ccagc/QDNAseq/issues/100

